### PR TITLE
Idempotency on payments

### DIFF
--- a/backend/api/httpx/middlewares/idempotency.go
+++ b/backend/api/httpx/middlewares/idempotency.go
@@ -1,0 +1,308 @@
+package mymiddlewares
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"rifa/backend/internal/repository"
+	"rifa/backend/pkg/logx"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+)
+
+type bodyCaptureCtx struct {
+	middleContext huma.Context
+	w             io.Writer
+}
+
+func (c bodyCaptureCtx) Operation() *huma.Operation {
+	return c.middleContext.Operation()
+}
+func (c bodyCaptureCtx) Context() context.Context {
+	return c.middleContext.Context()
+}
+func (c bodyCaptureCtx) TLS() *tls.ConnectionState {
+	return c.middleContext.TLS()
+}
+func (c bodyCaptureCtx) Version() huma.ProtoVersion {
+	return c.middleContext.Version()
+}
+func (c bodyCaptureCtx) Method() string {
+	return c.middleContext.Method()
+}
+func (c bodyCaptureCtx) Host() string {
+	return c.middleContext.Host()
+}
+func (c bodyCaptureCtx) RemoteAddr() string {
+	return c.middleContext.RemoteAddr()
+}
+func (c bodyCaptureCtx) URL() url.URL {
+	return c.middleContext.URL()
+}
+func (c bodyCaptureCtx) Param(name string) string {
+	return c.middleContext.Param(name)
+}
+func (c bodyCaptureCtx) Query(name string) string {
+	return c.middleContext.Query(name)
+}
+func (c bodyCaptureCtx) Header(name string) string {
+	return c.middleContext.Header(name)
+}
+func (c bodyCaptureCtx) EachHeader(cb func(name, value string)) {
+	c.middleContext.EachHeader(cb)
+}
+func (c bodyCaptureCtx) BodyReader() io.Reader {
+	return c.middleContext.BodyReader()
+}
+func (c bodyCaptureCtx) GetMultipartForm() (*multipart.Form, error) {
+
+	return c.middleContext.GetMultipartForm()
+}
+func (c bodyCaptureCtx) SetReadDeadline(t time.Time) error {
+	return c.middleContext.SetReadDeadline(t)
+}
+func (c bodyCaptureCtx) SetStatus(code int) { c.middleContext.SetStatus(code) }
+func (c bodyCaptureCtx) Status() int {
+	return c.middleContext.Status()
+}
+func (c bodyCaptureCtx) SetHeader(name, value string) {
+	c.middleContext.SetHeader(name, value)
+}
+func (c bodyCaptureCtx) AppendHeader(name, value string) {
+	c.middleContext.AppendHeader(name, value)
+}
+func (c bodyCaptureCtx) BodyWriter() io.Writer {
+	return c.w
+}
+
+const maxFileBytes int64 = 1 * 1024 * 1024
+
+func IdempotencyMiddleware(
+	api huma.API,
+	repo repository.IdempotencyRepository,
+	logger logx.Logger,
+) func(ctx huma.Context, next func(ctx huma.Context)) {
+	return func(ctx huma.Context, next func(ctx huma.Context)) {
+		key := ctx.Header("Idempotency-Key")
+		if key == "" {
+			next(ctx)
+			return
+		}
+
+		contentType := ctx.Header("Content-Type")
+		if !strings.HasPrefix(contentType, "multipart/form-data") {
+			logger.Warn(
+				"Invalid Content-Type for idempotent endpoint",
+				"type",
+				contentType,
+			)
+			_ = huma.WriteErr(
+				api,
+				ctx,
+				http.StatusBadRequest,
+				"Invalid Content-Type, expected multipart/form-data",
+				errors.New("invalid content-type"),
+			)
+			return
+		}
+
+		boundary := boundaryFromContentType(contentType)
+		if boundary == "" {
+			logger.Warn("Missing multipart boundary")
+			_ = huma.WriteErr(
+				api,
+				ctx,
+				http.StatusBadRequest,
+				"Missing multipart boundary",
+				errors.New("missing boundary"),
+			)
+			return
+		}
+
+		r, _ := humachi.Unwrap(ctx)
+		bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, maxFileBytes))
+		if err != nil {
+			logger.Error("Failed to read request body", "error", err)
+			_ = huma.WriteErr(
+				api,
+				ctx,
+				http.StatusBadRequest,
+				"Invalid request body",
+				err,
+			)
+			return
+		}
+
+		formReader := multipart.NewReader(bytes.NewReader(bodyBytes), boundary)
+		formValues := map[string]string{}
+
+		for {
+			part, err := formReader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				logger.Error("Failed to read multipart body", "error", err)
+				_ = huma.WriteErr(
+					api,
+					ctx,
+					http.StatusBadRequest,
+					"Invalid multipart body",
+					err,
+				)
+				return
+			}
+
+			name := part.FormName()
+			if part.FileName() != "" {
+				closeErr := part.Close()
+				if closeErr != nil {
+					logger.Warn(
+						"Failed to close file part",
+						"field",
+						name,
+						"error",
+						closeErr,
+					)
+				}
+				continue
+			}
+
+			data, readErr := io.ReadAll(part)
+			if closeErr := part.Close(); closeErr != nil {
+				logger.Warn(
+					"Failed to close form field part",
+					"field",
+					name,
+					"error",
+					closeErr,
+				)
+			}
+			if readErr != nil {
+				logger.Error(
+					"Failed to read form field",
+					"field",
+					name,
+					"error",
+					readErr,
+				)
+				_ = huma.WriteErr(
+					api,
+					ctx,
+					http.StatusBadRequest,
+					"Invalid form field",
+					readErr,
+				)
+				return
+			}
+
+			formValues[part.FormName()] = string(data)
+		}
+
+		cleanBody, err := json.Marshal(formValues)
+		if err != nil {
+			logger.Error("Failed to re-marshal cleaned JSON", "error", err)
+			_ = huma.WriteErr(
+				api,
+				ctx,
+				http.StatusInternalServerError,
+				"Failed to hash request",
+				err,
+			)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		sum := sha256.Sum256(cleanBody)
+		bodyHash := hex.EncodeToString(sum[:])
+
+		rec, err := repo.Get(ctx.Context(), key)
+		if err == nil {
+			if rec.BodyHash != bodyHash {
+				logger.Warn(
+					"Idempotency key reused with different payload",
+					"key",
+					key,
+				)
+				_ = huma.WriteErr(
+					api,
+					ctx,
+					http.StatusConflict,
+					"Idempotency key reused with different payload",
+					errors.New("payload mismatch"),
+				)
+				return
+			}
+			logger.Info("Idempotent replay detected", "key", key)
+			ctx.SetStatus(rec.StatusCode)
+			_, writeErr := ctx.BodyWriter().Write(rec.ResponseBody)
+			if writeErr != nil {
+				logger.Error(
+					"Failed to write cached response body",
+					"key",
+					key,
+					"error",
+					writeErr,
+				)
+			}
+			return
+		}
+
+		buf := new(bytes.Buffer)
+		mw := io.MultiWriter(ctx.BodyWriter(), buf)
+		captureCtx := bodyCaptureCtx{ctx, mw}
+
+		next(captureCtx)
+
+		status := captureCtx.Status()
+		saveErr := repo.Save(
+			captureCtx.Context(),
+			repository.IdempotencyRecord{
+				Key:          key,
+				BodyHash:     bodyHash,
+				StatusCode:   status,
+				ResponseBody: buf.Bytes(),
+			},
+		)
+		if saveErr != nil {
+			logger.Error(
+				"Failed to persist idempotency record",
+				"key",
+				key,
+				"error",
+				saveErr,
+			)
+		} else {
+			logger.Info(
+				"Stored new idempotency record",
+				"key",
+				key,
+				"status",
+				status,
+				"bytes",
+				buf.Len(),
+			)
+		}
+	}
+}
+
+func boundaryFromContentType(contentType string) string {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+	return params["boundary"]
+}

--- a/backend/api/httpx/purchase.go
+++ b/backend/api/httpx/purchase.go
@@ -12,6 +12,7 @@ import (
 	mymiddlewares "rifa/backend/api/httpx/middlewares"
 	"rifa/backend/internal/core/email"
 	"rifa/backend/internal/core/purchase"
+	"rifa/backend/internal/repository"
 	"rifa/backend/pkg/config"
 	database "rifa/backend/pkg/db"
 	"rifa/backend/pkg/logx"
@@ -36,6 +37,7 @@ func RegisterPurchaseRoutes(
 		opts.Email.EmailURL,
 	)
 	srv := purchase.NewService(db, logger, emailer)
+	idempotencyRepo := repository.NewIdempotencyRepository(db)
 
 	huma.Register(
 		api,
@@ -46,6 +48,11 @@ func RegisterPurchaseRoutes(
 			Summary:     "Submit a purchase",
 			Middlewares: huma.Middlewares{
 				mymiddlewares.RequireSession(api, opts.JwtOpts),
+				mymiddlewares.IdempotencyMiddleware(
+					api,
+					idempotencyRepo,
+					logger,
+				),
 			},
 			DefaultStatus: http.StatusCreated,
 		},

--- a/backend/cmd/app/main.go
+++ b/backend/cmd/app/main.go
@@ -6,8 +6,12 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
+	"rifa/backend/internal/background"
 	"rifa/backend/internal/core"
 	"rifa/backend/pkg/config"
 	database "rifa/backend/pkg/db"
@@ -32,9 +36,11 @@ func main() {
 	}
 
 	driver := database.NewPostgresDriver()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	dbAdapter, err := database.Connect(ctx, driver, &cfg.Database)
+	ctx := context.Background()
+	dbCtx, cancelDb := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelDb()
+
+	dbAdapter, err := database.Connect(dbCtx, driver, &cfg.Database)
 	if err != nil {
 		log.Fatalf("failed to start the db: %v", err)
 	}
@@ -45,13 +51,22 @@ func main() {
 		log.Fatalf("collector init: %v", err)
 	}
 	defer func() {
-		err = shutdown(context.Background())
+		err = shutdown(ctx)
 		if err != nil {
 			log.Fatalf("failed to shutdown collector: %v", err)
 		}
 	}()
 
 	logger := logx.NewLogger(cfg.Server.Env)
+	signalCtx, cancelSignal := signal.NotifyContext(
+		ctx,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer cancelSignal()
+
+	background.StartIdempotencyCleanup(signalCtx, dbAdapter, logger)
+
 	front := http.FS(dist)
 	server, err := core.NewHttpServer(
 		dbAdapter,
@@ -63,9 +78,30 @@ func main() {
 		},
 	)
 	if err != nil {
-		log.Fatal("failed to config the server")
+		logger.Error("Failed to configure server", "err", err)
+		os.Exit(1)
 	}
 
-	log.Println("Rifa backend listening on :" + cfg.Server.Port)
-	log.Fatal(server.ListenAndServe())
+	go func() {
+		logger.Info("Rifa backend listening", "port", cfg.Server.Port)
+		err := server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			logger.Error("HTTP server error", "err", err)
+			cancelSignal()
+		}
+	}()
+
+	<-signalCtx.Done()
+	logger.Info("Shutting down gracefully...")
+
+	shutdownCtx, cancel := context.WithTimeout(
+		ctx,
+		10*time.Second,
+	)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		logger.Error("Server forced to shutdown", "err", err)
+	}
+
+	logger.Info("Server exited cleanly")
 }

--- a/backend/internal/background/cleanup.go
+++ b/backend/internal/background/cleanup.go
@@ -1,0 +1,41 @@
+package background
+
+import (
+	"context"
+	"time"
+
+	"rifa/backend/pkg/db"
+	"rifa/backend/pkg/logx"
+)
+
+func StartIdempotencyCleanup(
+	ctx context.Context,
+	database db.DB,
+	logger logx.Logger,
+) {
+	ticker := time.NewTicker(time.Hour)
+	go func() {
+		defer ticker.Stop()
+		logger.Info("Started idempotency cleanup worker")
+
+		for {
+			select {
+			case <-ticker.C:
+				cleanupCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+				defer cancel()
+
+				err := database.ExecContext(
+					cleanupCtx,
+					`DELETE FROM idempotency_keys WHERE created_at < NOW() - INTERVAL '24 hours'`,
+				)
+				if err != nil {
+					logger.Error("Failed to cleanup idempotency_keys", "err", err)
+				}
+
+			case <-ctx.Done():
+				logger.Info("Stopping idempotency cleanup worker")
+				return
+			}
+		}
+	}()
+}

--- a/backend/internal/core/purchase/service.go
+++ b/backend/internal/core/purchase/service.go
@@ -123,11 +123,11 @@ func (s *service) Create(
 		return err
 	}
 
-	go func(ctx context.Context, p *types.Purchase) {
-		c, cancel := context.WithTimeout(ctx, 5*time.Second)
+	go func(p *types.Purchase) {
+		ct, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
-		err := s.emailer.SendPurchaseConfirmation(c, *p)
+		err := s.emailer.SendPurchaseConfirmation(ct, *p)
 		if err != nil {
 			s.logger.Warn(
 				"Failed to send the email purchase confirmation",
@@ -142,7 +142,7 @@ func (s *service) Create(
 		}
 
 		s.logger.Info("New purchase received and email send! ")
-	}(ctx, purchase)
+	}(purchase)
 
 	return nil
 }

--- a/backend/internal/repository/idempotency_repository.go
+++ b/backend/internal/repository/idempotency_repository.go
@@ -1,0 +1,56 @@
+package repository
+
+import (
+	"context"
+
+	"rifa/backend/pkg/db"
+)
+
+type IdempotencyRecord struct {
+	Key          string
+	BodyHash     string
+	StatusCode   int
+	ResponseBody []byte
+}
+
+type IdempotencyRepository interface {
+	Get(ctx context.Context, key string) (IdempotencyRecord, error)
+	Save(ctx context.Context, rec IdempotencyRecord) error
+}
+
+type idempotencyRepo struct{ db db.DB }
+
+func NewIdempotencyRepository(db db.DB) IdempotencyRepository {
+	return &idempotencyRepo{db: db}
+}
+
+func (r *idempotencyRepo) Get(
+	ctx context.Context,
+	key string,
+) (IdempotencyRecord, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT key, body_hash, status_code, response_body
+		FROM idempotency_keys
+		WHERE key = $1
+	`, key)
+
+	var rec IdempotencyRecord
+	err := row.Scan(&rec.Key, &rec.BodyHash, &rec.StatusCode, &rec.ResponseBody)
+	if err != nil {
+		return IdempotencyRecord{}, err
+	}
+
+	return rec, nil
+}
+
+func (r *idempotencyRepo) Save(ctx context.Context, rec IdempotencyRecord) error {
+	err := r.db.ExecContext(ctx, `
+		INSERT INTO idempotency_keys (key, body_hash, status_code, response_body)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (key) DO NOTHING
+	`, rec.Key, rec.BodyHash, rec.StatusCode, rec.ResponseBody)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/migrations/000000006_idempotency.down.sql
+++ b/backend/migrations/000000006_idempotency.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS idempotency_keys;

--- a/backend/migrations/000000006_idempotency.up.sql
+++ b/backend/migrations/000000006_idempotency.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+    key TEXT PRIMARY KEY,
+    body_hash TEXT NOT NULL,
+    status_code INT NOT NULL,
+    response_body BYTEA NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/frontend/src/api/purchase.ts
+++ b/frontend/src/api/purchase.ts
@@ -1,6 +1,8 @@
+import { buildIdempotencyKey } from '@src/utils/key';
 import { AuthError } from './auth';
 
 export async function submitPurchase(purchase: {
+  userId: string;
   quantity: number;
   montoBs: string;
   montoUSD: string;
@@ -23,13 +25,27 @@ export async function submitPurchase(purchase: {
   );
   formData.append('paymentScreenshot', purchase.paymentScreenshot);
 
-  const res = await fetch('/api/purchases', {
-    method: 'POST',
-    body: formData,
-    credentials: 'include',
-  });
-  if (!res.ok) {
-    throw new Error(await res.text());
+  let idempotencyKey = sessionStorage.getItem('currentPurchaseKey');
+  if (!idempotencyKey) {
+    idempotencyKey = await buildIdempotencyKey(purchase);
+    sessionStorage.setItem('currentPurchaseKey', idempotencyKey);
+  }
+
+  try {
+    const res = await fetch('/api/purchases', {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+      headers: {
+        'Idempotency-Key': idempotencyKey,
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+  } finally {
+    sessionStorage.removeItem('currentPurchaseKey');
   }
 }
 

--- a/frontend/src/landing/components/Actions.tsx
+++ b/frontend/src/landing/components/Actions.tsx
@@ -48,6 +48,7 @@ const Actions = ({ prices }: ActionsProps) => {
         </button>
 
         <PurchaseModal
+          userId={user ? user.id : ''}
           bs={prices && prices.montoBs ? prices.montoBs : MONTO_BS}
           usd={prices && prices.montoUsd ? prices.montoUsd : MONTO_USD}
           isOpen={purchaseModalOpen}

--- a/frontend/src/landing/components/BuyForm.test.tsx
+++ b/frontend/src/landing/components/BuyForm.test.tsx
@@ -22,6 +22,7 @@ function renderBuyFormUI(
   overrides?: Partial<React.ComponentProps<typeof BuyForm>>,
 ) {
   const props: React.ComponentProps<typeof BuyForm> = {
+    userId: '1234a',
     quantity: 2,
     montoBs: 200,
     montoUSD: 20,

--- a/frontend/src/landing/components/BuyForm.tsx
+++ b/frontend/src/landing/components/BuyForm.tsx
@@ -5,6 +5,7 @@ import { CopyableText } from '@src/components/Clipboard/Copy';
 import { toast } from 'sonner';
 
 interface BuyFormProps {
+  userId: string;
   quantity: number;
   montoBs: number;
   montoUSD: number;
@@ -20,6 +21,7 @@ const paymentMethods = {
 } as const;
 
 export const BuyForm = ({
+  userId,
   quantity,
   montoBs,
   montoUSD,
@@ -65,6 +67,7 @@ export const BuyForm = ({
 
     try {
       await submitPurchase({
+        userId,
         quantity,
         montoBs: montoBs.toFixed(2),
         montoUSD: montoUSD.toFixed(2),

--- a/frontend/src/landing/components/PurchaseModal.test.tsx
+++ b/frontend/src/landing/components/PurchaseModal.test.tsx
@@ -14,13 +14,27 @@ describe('<PurchaseModal /> integration (real QS + Payment)', () => {
 
   it('renders null when closed', () => {
     const { container } = render(
-      <PurchaseModal bs={100} usd={10} isOpen={false} onClose={() => {}} />,
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen={false}
+        onClose={() => {}}
+      />,
     );
     expect(container.firstChild).toBeNull();
   });
 
   it('flows Quantity -> PaymentMethods -> BuyForm with default qty (2)', async () => {
-    render(<PurchaseModal bs={100} usd={10} isOpen onClose={() => {}} />);
+    render(
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen
+        onClose={() => {}}
+      />,
+    );
     // Step 1
     const next1 = screen.getByRole('button', { name: 'Siguiente' });
     expect(next1).toBeEnabled();
@@ -41,7 +55,15 @@ describe('<PurchaseModal /> integration (real QS + Payment)', () => {
   });
 
   it('allows changing quantity (to 3) before proceeding and passes updated amounts', async () => {
-    render(<PurchaseModal bs={100} usd={10} isOpen onClose={() => {}} />);
+    render(
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen
+        onClose={() => {}}
+      />,
+    );
 
     const inc = screen.getByLabelText('Aumentar cantidad');
     await userEvent.click(inc);
@@ -60,7 +82,15 @@ describe('<PurchaseModal /> integration (real QS + Payment)', () => {
   });
 
   it('PaymentMethods: Next disabled until selected; toggling off disables again', async () => {
-    render(<PurchaseModal bs={100} usd={10} isOpen onClose={() => {}} />);
+    render(
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen
+        onClose={() => {}}
+      />,
+    );
 
     await userEvent.click(screen.getByRole('button', { name: 'Siguiente' }));
 
@@ -76,7 +106,15 @@ describe('<PurchaseModal /> integration (real QS + Payment)', () => {
   });
 
   it('PaymentMethods: "Atrás" returns to Quantity step', async () => {
-    render(<PurchaseModal bs={100} usd={10} isOpen onClose={() => {}} />);
+    render(
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen
+        onClose={() => {}}
+      />,
+    );
 
     await userEvent.click(screen.getByRole('button', { name: 'Siguiente' }));
 
@@ -90,7 +128,15 @@ describe('<PurchaseModal /> integration (real QS + Payment)', () => {
 
   it('PaymentMethods: "Cerrar" calls onClose and resets internal step to Quantity', async () => {
     const onClose = vi.fn();
-    render(<PurchaseModal bs={100} usd={10} isOpen onClose={onClose} />);
+    render(
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen
+        onClose={onClose}
+      />,
+    );
 
     await userEvent.click(screen.getByRole('button', { name: 'Siguiente' }));
 
@@ -105,7 +151,15 @@ describe('<PurchaseModal /> integration (real QS + Payment)', () => {
 
   it('BuyForm: "bf-back" returns to Payment; "bf-close" calls onClose and resets to Quantity', async () => {
     const onClose = vi.fn();
-    render(<PurchaseModal bs={100} usd={10} isOpen onClose={onClose} />);
+    render(
+      <PurchaseModal
+        userId={'1234a'}
+        bs={100}
+        usd={10}
+        isOpen
+        onClose={onClose}
+      />,
+    );
 
     await userEvent.click(screen.getByRole('button', { name: 'Siguiente' }));
     await userEvent.click(

--- a/frontend/src/landing/components/PurchaseModal.tsx
+++ b/frontend/src/landing/components/PurchaseModal.tsx
@@ -4,6 +4,7 @@ import { PaymentMethods } from './PaymentMethods';
 import { BuyForm } from './BuyForm';
 
 interface PurchaseModalProps {
+  userId: string;
   bs: number;
   usd: number;
   isOpen: boolean;
@@ -19,6 +20,7 @@ const steps = {
 type PurchaseSteps = (typeof steps)[keyof typeof steps];
 
 export const PurchaseModal = ({
+  userId,
   bs,
   usd,
   isOpen,
@@ -78,6 +80,7 @@ export const PurchaseModal = ({
         )}
         {step === steps.BUY_FORM && (
           <BuyForm
+            userId={userId}
             quantity={quantity}
             montoBs={montoBs}
             montoUSD={montoUSD}

--- a/frontend/src/utils/key.ts
+++ b/frontend/src/utils/key.ts
@@ -1,0 +1,24 @@
+export async function buildIdempotencyKey(purchase: {
+  userId: string;
+  quantity: number;
+  montoBs: string;
+  montoUSD: string;
+  paymentMethod: string;
+  transactionDigits: string;
+  selectedNumbers: string[];
+}): Promise<string> {
+  const payload = JSON.stringify({
+    userId: purchase.userId,
+    quantity: purchase.quantity,
+    montoBs: purchase.montoBs,
+    montoUSD: purchase.montoUSD,
+    paymentMethod: purchase.paymentMethod,
+    transactionDigits: purchase.transactionDigits,
+    selectedNumbers: purchase.selectedNumbers.sort(),
+  });
+
+  const buffer = new TextEncoder().encode(payload);
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  const hashArray = Array.from(new Uint8Array(digest));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}


### PR DESCRIPTION
- Add migration for a new table to check for idempotency
- Add a background routine to clear idempotency expired keys 
- Build the idempotency key on the frontend
- Add unit tests
- Add middleware checker for idempotency
- Separate context on main file and adapt a better shutdown strategy
- Fix context on email being cancelled before atempting to send the email